### PR TITLE
ci: add ox_lib & remove polyzone in extra_libs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           capture: "junit.xml"
           args: "-t --formatter JUnit"
-          extra_libs: mysql+polyzone+qblocales
+          extra_libs: mysql+ox_lib+qblocales
       - name: Generate Lint Report
         if: always()
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
## Description

Added `ox_lib` and removed `polyzone` from `extra_libs`. All tests should pass successfully now.

*Note: This change seems to be already implemented on the `next` branch. However, that branch has no associated PR and hasn't been touched in 9 months, hence why this PR addresses the `main` branch directly.*

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
