### PR TITLE
feat: Added the playEmoteByCommand and cancelEmote exports in the config for users to change if they are not using scully_emotemenu.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -289,7 +289,7 @@ local function getInTrunk()
             clip = 'hotwire'
         },
     }) then
-        exports.scully_emotemenu:playEmoteByCommand('box')
+        config.playEmoteByCommand('box')
         hasBox = true
         exports.qbx_core:Notify(locale('info.deliver_to_store'), 'info')
     else
@@ -314,7 +314,7 @@ local function deliver()
             clip = 'hotwire'
         },
     }) then
-        exports.scully_emotemenu:cancelEmote()
+        config.cancelEmote()
         ClearPedTasks(cache.ped)
         hasBox = false
         currentLocation.currentCount += 1
@@ -334,7 +334,7 @@ local function deliver()
         end
     else
         ClearPedTasks(cache.ped)
-        exports.scully_emotemenu:cancelEmote()
+        config.cancelEmote()
         exports.qbx_core:Notify(locale('error.cancelled'), 'error')
     end
 end

--- a/config/client.lua
+++ b/config/client.lua
@@ -2,5 +2,18 @@ return {
     useTarget = GetConvar('UseTarget', 'false') == 'true',
     vehicles = {
         [`rumpo`] = 'Dumbo Delivery',
-    }
+    },
+    ---Default behaviour: Plays an emote using scully_emotemenu by command name
+    ---Change to the export your emote menu is using if not using scully_emotemenu
+    ---@param emote string The emote command to play
+    ---@return nil
+    playEmoteByCommand = function (emote)
+        return exports.scully_emotemenu:playEmoteByCommand(emote)
+    end,
+    ---Default behaviour: Cancels current emote using scully_emotemenu
+    ---Change to the export your emote menu is using if not using scully_emotemenu
+    ---@return nil
+    cancelEmote = function ()
+        return exports.scully_emotemenu:cancelEmote()
+    end
 }


### PR DESCRIPTION
## Description

feat: Added the playEmoteByCommand and cancelEmote exports in the config for users to change if they are not using scully_emotemenu.
This was done in response to qbx_truckerjob issue #31 

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
